### PR TITLE
Fix HTML warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,11 +7,11 @@
     
     <!-- External Libraries -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&amp;display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600;700&amp;display=swap" rel="stylesheet">
     <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
-    <script src="https://unpkg.com/dexie@3.2.3/dist/dexie.min.js"></script>
-    <script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>
+    <script src="https://unpkg.com/dexie@3.2.3/dist/dexie.min.js" defer></script>
+    <script src="https://cdn.quilljs.com/1.3.6/quill.min.js" defer></script>
 
     <style>
         :root {
@@ -732,7 +732,7 @@
                     </div>
                     <div class="project-detail-content">
                         <div class="project-detail-main">
-                            <div class="project-detail-image"><div class="no-image-placeholder"><i class="fas fa-image"></i></div></div>
+                            <div class="project-detail-image" aria-label="Project image"><div class="no-image-placeholder" aria-hidden="true"><i class="fas fa-image"></i></div></div>
                             <div class="project-detail-info">
                                 <h2 id="project-detail-title"></h2>
                                 <div id="project-detail-status"></div>


### PR DESCRIPTION
## Summary
- escape ampersands in Google Fonts links
- defer external JS scripts for faster loading
- improve accessibility for project detail image

## Testing
- `tidy -e index.html`

------
https://chatgpt.com/codex/tasks/task_e_683f44c51a98832480066aadce70166d