### PR TITLE
Implement login and rename to Task Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FinaFlow
+# Task Manager
 
 This repository now includes a small Node.js backend used for optional data synchronisation.
 

--- a/finaflow.html
+++ b/finaflow.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>FinaFlow - Task & Project Manager</title>
+    <title>Task Manager - Task & Project Manager</title>
     
     <!-- External Libraries -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
@@ -176,6 +176,7 @@
         }
         #manual-backup-btn { background-color: var(--lavender); color: var(--primary-color); }
         #restore-backup-btn { background-color: var(--warning-color); color: var(--primary-color); }
+        #sync-btn { background-color: red; }
 
         /* Task Container & Action Toolbar */
         .task-container { display: flex; flex-direction: column; gap: 25px; animation: slideInUp 0.5s ease; }
@@ -689,7 +690,7 @@
 <body>
     <div class="app-container">
         <header>
-            <div class="logo-wrapper"><img src="logo.png" alt="FinaFlow logo" class="logo-img"><span class="logo-text">FinaFlow</span></div>
+            <div class="logo-wrapper"><img src="logo.png" alt="Task Manager logo" class="logo-img"><span class="logo-text">Task Manager</span></div>
             <div class="view-controls">
                 <button id="active-view-btn" class="view-btn active">Active Tasks</button>
                 <button id="waiting-view-btn" class="view-btn">Waiting Tasks</button>
@@ -1273,6 +1274,8 @@
         async function ensureAuth() {
             const tokenSetting = await getDexie(STORES.SETTINGS, 'authToken');
             if (tokenSetting && tokenSetting.value) return tokenSetting.value;
+            const lsToken = localStorage.getItem('authToken');
+            if (lsToken) { await saveSetting('authToken', lsToken); return lsToken; }
             const username = prompt('Username:');
             const password = prompt('Password:');
             if (!username || !password) return null;
@@ -1284,6 +1287,7 @@
             if (!res.ok) { showToast('Login failed', 'error'); return null; }
             const data = await res.json();
             await saveSetting('authToken', data.token);
+            localStorage.setItem('authToken', data.token);
             return data.token;
         }
 
@@ -2467,7 +2471,7 @@
         async function saveBackupToFileSystem(jsonString) {
             try {
                 const blob = new Blob([jsonString], { type: 'application/json' });
-                const filename = `FinaFlow_Backup_${new Date().toISOString().slice(0,10)}.json`;
+                const filename = `TaskManager_Backup_${new Date().toISOString().slice(0,10)}.json`;
                 if (window.showSaveFilePicker) { 
                     const handle = await window.showSaveFilePicker({ suggestedName: filename, types: [{ description: 'JSON Files', accept: {'application/json': ['.json']} }] });
                     const writable = await handle.createWritable();
@@ -2749,8 +2753,8 @@
             updateAllTaskPriorities(true); 
 
             initAutoBackup(); 
-            console.log('FinaFlow Initialized.');
-            showToast('Welcome back to FinaFlow!', 'info', 2000);
+            console.log('Task Manager Initialized.');
+            showToast('Welcome back to Task Manager!', 'info', 2000);
         }
     document.addEventListener('DOMContentLoaded', init);
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Fina - Management Software</title>
+    <title>FinaFlow - Management Software</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600;700&display=swap" rel="stylesheet">
@@ -67,18 +67,53 @@
             box-shadow:var(--shadow-md);
             background-color:var(--accent-color);
         }
+        .login-container {
+            display:flex;
+            flex-direction:column;
+            gap:15px;
+            background-color:var(--secondary-color);
+            padding:25px;
+            border-radius:var(--border-radius-md);
+            width:100%;
+            max-width:300px;
+            margin-bottom:30px;
+        }
+        .login-container input {
+            padding:10px 15px;
+            border-radius:var(--border-radius-sm);
+            border:1px solid var(--accent-color);
+            background-color:var(--primary-color);
+            color:var(--text-color);
+        }
+        .login-container button {
+            padding:10px 15px;
+            border:none;
+            border-radius:var(--border-radius-sm);
+            background-color:var(--accent-color);
+            color:var(--offwhite);
+            cursor:pointer;
+            transition:var(--transition-std);
+        }
+        .login-container button:hover {
+            filter:brightness(1.1);
+        }
         @keyframes fadeIn { from{opacity:0;} to{opacity:1;} }
     </style>
 </head>
 <body>
     <header class="main-header">
-        <h1 class="main-title">Fina</h1>
+        <h1 class="main-title">FinaFlow</h1>
         <p class="sub-title">Management Software</p>
     </header>
-    <div class="menu-grid">
+    <div id="login-container" class="login-container">
+        <input type="text" id="username" placeholder="Username">
+        <input type="password" id="password" placeholder="Password">
+        <button id="login-btn">Login / Create Account</button>
+    </div>
+    <div id="menu-grid" class="menu-grid" style="display:none;">
         <a href="finaflow.html" class="menu-item">
             <i class="fas fa-stream"></i>
-            <span>Finaflow</span>
+            <span>Task Manager</span>
         </a>
         <a href="#" class="menu-item">
             <i class="fas fa-box"></i>
@@ -101,5 +136,31 @@
             <span>Placeholder 5</span>
         </a>
     </div>
+    <script>
+        const loginContainer = document.getElementById('login-container');
+        const menuGrid = document.getElementById('menu-grid');
+        async function login() {
+            const username = document.getElementById('username').value.trim();
+            const password = document.getElementById('password').value.trim();
+            if (!username || !password) { alert('Enter credentials'); return; }
+            const res = await fetch('/api/login', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username, password })
+            });
+            if (!res.ok) { alert('Login failed'); return; }
+            const data = await res.json();
+            localStorage.setItem('authToken', data.token);
+            loginContainer.style.display = 'none';
+            menuGrid.style.display = 'grid';
+        }
+        document.getElementById('login-btn').addEventListener('click', login);
+        window.addEventListener('DOMContentLoaded', () => {
+            if (localStorage.getItem('authToken')) {
+                loginContainer.style.display = 'none';
+                menuGrid.style.display = 'grid';
+            }
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rename the project to **Task Manager**
- add login and account creation screen on the homepage
- persist authentication token for sync
- update the app header and backup filename
- style the sync button red

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f62e2db2c8324914040a401172858