### PR TITLE
Enable Firestore sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Task Manager
 
-FinaFlow is an in-browser task and project manager. All data is stored locally using IndexedDB through Dexie.js so no server setup or login is required.
+FinaFlow is an in-browser task and project manager. Data is stored locally using IndexedDB through Dexie.js and also synced to Firebase Firestore so your tasks follow you across devices.
 
 Open `index.html` to access the main menu and launch the task manager interface in `finaflow.html`.
 
 ## Development
 
-All functionality lives in the two HTML files and the bundled Dexie library. Simply open the files in a modern browser. Data persists in your browser until cleared.
+All functionality lives in the two HTML files and the bundled Dexie library. Simply open the files in a modern browser. Data is saved locally and synced to Firestore whenever you hit a Save or Update button.

--- a/finaflow.html
+++ b/finaflow.html
@@ -1148,10 +1148,26 @@
         // --- Dexie Helper Functions ---
         async function getAllDexie(storeName) { return db.table(storeName).toArray(); }
         async function getDexie(storeName, key) { return db.table(storeName).get(key); }
-        async function addDexie(storeName, item) { return db.table(storeName).add(item); }
-        async function putDexie(storeName, item) { return db.table(storeName).put(item); } 
-        async function deleteDexieItem(storeName, key) { return db.table(storeName).delete(key); }
-        async function clearDexieStore(storeName) { return db.table(storeName).clear(); }
+        async function addDexie(storeName, item) {
+            const result = await db.table(storeName).add(item);
+            if (window.save) window.save();
+            return result;
+        }
+        async function putDexie(storeName, item) {
+            const result = await db.table(storeName).put(item);
+            if (window.save) window.save();
+            return result;
+        }
+        async function deleteDexieItem(storeName, key) {
+            const result = await db.table(storeName).delete(key);
+            if (window.save) window.save();
+            return result;
+        }
+        async function clearDexieStore(storeName) {
+            const result = await db.table(storeName).clear();
+            if (window.save) window.save();
+            return result;
+        }
 
         
         // --- Utility Functions ---
@@ -1215,6 +1231,7 @@
                         await db.table(storeName).bulkPut(dataToSave);
                     }
                 }
+                if (window.save) window.save();
             } catch (error) { console.error(`Error saving to ${storeName}:`, error); showToast(`Error saving to ${storeName}.`, 'error'); }
         }
         async function saveSetting(key, value) { await putDexie(STORES.SETTINGS, { key, value }); }
@@ -2831,6 +2848,7 @@
     const data = await collectFormData();
     await setDoc(docRef, data, { merge:true });
   }
+  window.save = save;
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- connect to Firebase Firestore
- auto-call `save()` when Dexie writes occur
- expose `save()` globally
- document remote sync in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f70d33fb4832492a85d246078f397