### PR TITLE
Fix navigation listeners and remove unused concept section

### DIFF
--- a/app.js
+++ b/app.js
@@ -136,13 +136,13 @@
 
         switch (pageId) {
             case 'index': this.renderDashboard(); break;
-            case 'tasks-page': this.renderTasksPage(); break;
-            case 'projects-page': this.renderProjectsPage(); break;
-            case 'notes-page': this.renderNotesPage(); break;
-            case 'habits-page': this.renderHabitsPage(); break;
-            case 'household-page': this.renderHouseholdPage(); break;
-            case 'timemanagement-page': this.renderTimeManagementPage(); break;
-            case 'settings-page': this.renderSettingsPage(); break;
+            case 'tasks': this.renderTasksPage(); break;
+            case 'projects': this.renderProjectsPage(); break;
+            case 'notes': this.renderNotesPage(); break;
+            case 'habits': this.renderHabitsPage(); break;
+            case 'household': this.renderHouseholdPage(); break;
+            case 'timemanagement': this.renderTimeManagementPage(); break;
+            case 'settings': this.renderSettingsPage(); break;
         }
     };
 
@@ -166,13 +166,13 @@
         // Page-specific listeners
         switch (pageId) {
             case 'index': this.setupDashboardListeners(); break;
-            case 'tasks-page': this.setupTasksPageListeners(); break;
-            case 'projects-page': this.setupProjectsPageListeners(); break;
-            case 'notes-page': this.setupNotesPageListeners(); break;
-            case 'habits-page': this.setupHabitsPageListeners(); break;
-            case 'household-page': this.setupHouseholdPageListeners(); break;
-            case 'timemanagement-page': this.setupTimeManagementPageListeners(); break;
-            case 'settings-page': this.setupSettingsPageListeners(); break;
+            case 'tasks': this.setupTasksPageListeners(); break;
+            case 'projects': this.setupProjectsPageListeners(); break;
+            case 'notes': this.setupNotesPageListeners(); break;
+            case 'habits': this.setupHabitsPageListeners(); break;
+            case 'household': this.setupHouseholdPageListeners(); break;
+            case 'timemanagement': this.setupTimeManagementPageListeners(); break;
+            case 'settings': this.setupSettingsPageListeners(); break;
         }
     };
     

--- a/index.html
+++ b/index.html
@@ -56,18 +56,6 @@
                 </div>
             </div>
 
-            <!-- Quick Concept -->
-            <div class="dashboard-card" id="dashboard-quick-concept">
-                <div class="card-header">
-                    <h3><i class="fas fa-lightbulb"></i> Quick Concept</h3>
-                    <a href="projects.html" class="card-link">View All &rarr;</a>
-                </div>
-                <div class="card-content">
-                    <input type="text" id="dashboard-concept-title" placeholder="Concept Title...">
-                    <textarea id="dashboard-concept-text" placeholder="Jot down a new idea..."></textarea>
-                    <button id="dashboard-save-concept-btn" class="submit-btn small-btn">Save Concept</button>
-                </div>
-            </div>
 
             <!-- Household Status -->
             <div class="dashboard-card" id="dashboard-household">


### PR DESCRIPTION
## Summary
- ensure correct page IDs for listener/router logic
- remove Quick Concept widget from dashboard

## Testing
- `node -c app.js`

------
https://chatgpt.com/codex/tasks/task_e_684992878b7083248e26a3205eeb33c7