### PR TITLE
Implement missing page listeners and tag deletion

### DIFF
--- a/tasks.html
+++ b/tasks.html
@@ -117,7 +117,7 @@
             <input type="hidden" id="edit-tag-id">
             <div class="form-group"><label for="edit-tag-name">Tag Name</label><input type="text" id="edit-tag-name" required></div>
             <div class="form-group"><label for="edit-tag-color">Tag Color</label><input type="color" id="edit-tag-color" required></div>
-            <div class="form-actions"><button type="button" class="cancel-btn">Cancel</button><button type="submit" class="submit-btn">Save</button></div>
+            <div class="form-actions"><button type="button" id="delete-tag-btn" class="delete-btn">Delete Tag</button><button type="button" class="cancel-btn">Cancel</button><button type="submit" class="submit-btn">Save</button></div>
         </form></div>
     </div></div>
     


### PR DESCRIPTION
## Summary
- enable deleting task tags via edit modal
- flesh out project, notes, household, habits and time management page logic
- add basic listeners and rendering for previously empty pages

## Testing
- `node -e "require('./app.js')"` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684996e26a388324a30feab4f3a0aa37